### PR TITLE
specify node version directly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3.0.0
         with:
-          node-version-file: ".nvmrc"
+          node-version: 16.14.0
+          # node-version-file: ".nvmrc"
 
       - name: Checkout branch
         uses: actions/checkout@v2


### PR DESCRIPTION
Why?
node-version-file doesn't seem to work

Ref: https://github.com/jayaganeshk/crystalcars/runs/5591584569?check_suite_focus=true#step:2:7